### PR TITLE
개발 단계 CORS 정책 허용 (#23)

### DIFF
--- a/server/Program.cs
+++ b/server/Program.cs
@@ -9,6 +9,13 @@ builder.Services.AddControllers();
 // Dependency injection (services)
 builder.Services.AddDbContext<ApplicationDbContext>();
 builder.Services.AddScoped<UserService>();
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy(name: "develop", policy =>
+    {
+        policy.AllowAnyMethod().AllowAnyHeader().AllowAnyOrigin();
+    });
+});
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
@@ -30,4 +37,3 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.Run();
-

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -9,13 +9,6 @@ builder.Services.AddControllers();
 // Dependency injection (services)
 builder.Services.AddDbContext<ApplicationDbContext>();
 builder.Services.AddScoped<UserService>();
-builder.Services.AddCors(options =>
-{
-    options.AddPolicy(name: "develop", policy =>
-    {
-        policy.AllowAnyMethod().AllowAnyHeader().AllowAnyOrigin();
-    });
-});
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
@@ -31,6 +24,16 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseRouting();
+
+app.Use((context, next) =>
+{
+    context.Response.Headers["Access-Control-Allow-Origin"] = "*";  
+    context.Response.Headers["Access-Control-Allow-Header"] = "*";
+    context.Response.Headers["Access-Control-Allow-Method"] = "*";
+    return next.Invoke();
+});
 
 app.UseAuthorization();
 


### PR DESCRIPTION
## 개요
개발 시에는 각 개발자의 개별 IP에서 접속하기 때문에 CORS 정책에 따라 통신이 제한됩니다. 개발단계에서는 이 부분을 일시적으로 허용하기 위해서 CORS 정책 헤더의 변경이 필요합니다.

## 조치사항
CORS 정책 헤더를 설정하기 위해 별도의 MiddleWare를 구성하여 `Access-Control-Allow-` `Origin, Header, Method`를 `*`로 허용했습니다.

## 이후 필요 조치사항
CORS 정책을 관리하는 추가적인 패키지를 확인해봐야 하며, 릴리즈 단계에서는 CORS 정책을 수정해야합니다.