### PR TITLE
개발단계에서 Swagger 문서를 확인할 수 없는 문제(#25)

### DIFF
--- a/server/Program.cs
+++ b/server/Program.cs
@@ -17,7 +17,9 @@ builder.Services.AddSwaggerGen();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
+bool isSwagger = app.Configuration.GetValue<bool>("swagger");
+
+if (app.Environment.IsDevelopment() || isSwagger)
 {
     app.UseSwagger();
     app.UseSwaggerUI();


### PR DESCRIPTION
## 개요
- 개발서버에서 swagger 페이지를 접속할 수 없다는 문제가 발생되었습니다.
- 배포단계에서도 필요에 따라서 swagger 페이지에 접속할 수 있도록 하는 기능 요구이 요구되었습니다.

## 수정사항
- `dotnet publish` 명령어로 배포된 서버 프로그램에서도 명령행 인자를 사용해서 swagger 옵션을 켤수 있도록 했습니다.
- `dotnet path/to/server.dll swagger="true"`와 같이 서버를 실행할 수 있습니다.
- 옵션을 설정하지 않은 경우(`dotnet path/to/server/dll`) swagger 페이지에 접근할 수 없도록 했습니다.

## 참고자료
- [Command-line arguments](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-7.0#command-line-arguments)
- [Default host configuration sources](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-7.0#default-host-configuration-sources)